### PR TITLE
Add EnvironmentConfigProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,25 @@ Then, reference the secret files in Kafka or Kafka Connect configuration:
     }
 }
 ```
+
+## EnvironmentConfigProvider
+
+This reads the value from an environment variable. Useful when using the [env option of externalConfiguration](https://strimzi.io/docs/operators/0.22.1/using.html#property-kafka-connect-external-env-reference).
+
+Add the following to the KafkaConnect custom resource's `spec.config`:
+
+
+```properties
+config.providers: env
+config.providers.file.class: com.redhat.insights.kafka.config.providers.EnvironmentConfigProvider
+```
+
+Then, reference the environment variables in a Kafka or Kafka Connect configuration:
+
+```json
+{
+    "config": {
+        "database.hostname": "${env:HBI_DB_HOSTNAME}"
+    }
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,14 @@
             <version>1.7.32</version>
             <scope>test</scope>
           </dependency>
+
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
 
-        <version.junit>4.13.2</version.junit>
+        <version.junit>5.7.2</version.junit>
         <version.kafka>2.7.0</version.kafka>
 
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
@@ -71,16 +71,16 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
             <version>${version.junit}</version>
-            <scope>test</scope>
+			<scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
             <scope>test</scope>
           </dependency>
     </dependencies>

--- a/src/main/java/com/redhat/insights/kafka/config/providers/EnvironmentConfigProvider.java
+++ b/src/main/java/com/redhat/insights/kafka/config/providers/EnvironmentConfigProvider.java
@@ -1,0 +1,47 @@
+package com.redhat.insights.kafka.config.providers;
+
+import org.apache.kafka.common.config.ConfigData;
+import org.apache.kafka.common.config.provider.ConfigProvider;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link ConfigProvider} implementation that reads values from environment variables.
+ *
+ * Example:
+ *
+ * "database.password": "${env:DB_PASSWORD}",
+ */
+public class EnvironmentConfigProvider implements ConfigProvider {
+
+    @Override
+    public void configure(Map<String, ?> cfg) {
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public ConfigData get(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConfigData get(String path, Set<String> keys) {
+        if (path == null || path.length() != 0) {
+            throw new IllegalArgumentException("Only basic syntax (e.g. ${env:VARIABLE_NAME}) is supported");
+        }
+
+        return new ConfigData(keys.stream().collect(Collectors.toMap(key -> key, key -> {
+            String value = System.getenv(key);
+            if (value == null) {
+                throw new EnvironmentVariableMissingException("Environment variable " + key + " not found");
+            }
+            return value;
+        })));
+    }
+}

--- a/src/main/java/com/redhat/insights/kafka/config/providers/EnvironmentVariableMissingException.java
+++ b/src/main/java/com/redhat/insights/kafka/config/providers/EnvironmentVariableMissingException.java
@@ -1,0 +1,9 @@
+package com.redhat.insights.kafka.config.providers;
+
+public class EnvironmentVariableMissingException extends RuntimeException {
+    private static final long serialVersionUID = 3283717955744967347L;
+
+    public EnvironmentVariableMissingException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/redhat/insights/kafka/config/providers/EnvironmentConfigProviderTest.java
+++ b/src/test/java/com/redhat/insights/kafka/config/providers/EnvironmentConfigProviderTest.java
@@ -1,0 +1,45 @@
+package com.redhat.insights.kafka.config.providers;
+
+import org.apache.kafka.common.config.ConfigData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class EnvironmentConfigProviderTest {
+
+    private EnvironmentConfigProvider instance;
+
+    @BeforeEach
+    public void init() {
+        instance = new EnvironmentConfigProvider();
+        instance.configure(Collections.emptyMap());
+    }
+
+    @AfterEach
+    public void close() throws IOException {
+        instance.close();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "DATABASE_HOSTNAME", value = "a.test.db")
+    public void testReadingEnvironmentVariable() {
+        final ConfigData result = instance.get("", Collections.singleton("DATABASE_HOSTNAME"));
+        assertEquals("a.test.db", result.data().get("DATABASE_HOSTNAME"));
+    }
+
+    @Test
+    public void testExceptionWhenMissingEnvironmentVariable() {
+        assertThrows(EnvironmentVariableMissingException.class, () -> instance.get("", Collections.singleton("key")));
+    }
+
+    @Test
+    public void testExceptionThrownOnPathPlusKey() {
+        assertThrows(IllegalArgumentException.class, () -> instance.get("path", Collections.singleton("key")));
+    }
+}

--- a/src/test/java/com/redhat/insights/kafka/config/providers/PlainFileConfigProviderTest.java
+++ b/src/test/java/com/redhat/insights/kafka/config/providers/PlainFileConfigProviderTest.java
@@ -1,7 +1,10 @@
 package com.redhat.insights.kafka.config.providers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,21 +16,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.ConfigData;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class PlainFileConfigProviderTest {
 
     private PlainFileConfigProvider instance;
 
-    @Before
+    @BeforeEach
     public void init() {
         instance = new PlainFileConfigProvider();
         instance.configure(Collections.emptyMap());
     }
 
-    @After
+    @AfterEach
     public void close() throws IOException {
         instance.close();
     }


### PR DESCRIPTION
I was unable to use FileConfigProvider (or the Plain one) due to permission issues in our clusters. For some reason the permissions on the files is set to read only for the root user, so Kafka Connect is unable to read the files when loading the connector definitions. So I'm going to load the secrets into environment variables instead then use the EnvironmentConfigProvider to read them in the connector definitions.